### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,8 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show ]
+  
   def index
+    @items = Item.includes(:user).all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show ]
   
   def index
-    @items = Item.includes(:user).all
+    @items = Item.includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,10 +129,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -143,16 +144,17 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.delivery_time %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,17 +128,17 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      
       <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# 商品が売れていればsold outを表示する機能→こちらは商品購入機能実装後に実装する %>
+         <!-- <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> -->
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -147,7 +147,7 @@
             <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.delivery_time %></span>
+            <span><%= item.price %>円<br><%= item.shipping_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,10 +157,9 @@
         <% end %>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+      <% unless Item.where.not(item_name: nil).exists? %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -177,9 +176,10 @@
           </div>
         </div>
         <% end %>
+         
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
+    
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
消費一覧表示機能を実装しましたのでコードレビューをお願いします。

What
商品一覧表示ページは、ログイン状況に関係なく閲覧できるよう実装
出品されている商品が一覧表示を実装
商品が出品されていない状態では、ダミーの商品情報が表示されるよう実装
左上から、出品された日時が新しい順に表示されるよう実装
商品出品時に登録した情報のうち、「画像・商品名・価格・配送料の負担」の4つの情報が、見本アプリと同様の形で表示されるよう実装
売却済みの商品は、画像上に「sold out」の文字が表示されること。左記の機能については、購入機能実装後に実装します。

以下、動作検証動画になります。ご確認ください。

商品が2つ以上登録された場合登録日順に並ぶ動画
https://gyazo.com/e2b240ff9a3c629955c42f8dc815d7d0

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/6b9301c86f1466483092813dbbb7b427

よろしくお願いします。